### PR TITLE
Make Kubernetes manifests deploy properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.15-buster
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
 		nodejs \

--- a/db-claim0-persistentvolumeclaim.yaml
+++ b/db-claim0-persistentvolumeclaim.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/db-deployment.yaml
+++ b/db-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/db-deployment.yaml
+++ b/db-deployment.yaml
@@ -38,7 +38,7 @@ spec:
         name: db
         resources: {}
         volumeMounts:
-        - mountPath: /docker-entrypoint-initdb.d/db.sql
+        - mountPath: /docker-entrypoint-initdb.d
           name: db-claim0
       restartPolicy: Always
       serviceAccountName: ""

--- a/db-service.yaml
+++ b/db-service.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+  name: db
+spec:
+  ports:
+  - name: "postgres"
+    port: 5432
+    targetPort: 5432
+  selector:
+    io.kompose.service: db

--- a/jqplay-deployment.yaml
+++ b/jqplay-deployment.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/jqplay-deployment.yaml
+++ b/jqplay-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         - name: DATABASE_URL
           value: postgres://jqplay-user:jqplay-pass@db/jqplay-db?sslmode=disable
         image: jqplay:latest
-        imagePullPolicy: ""
+        imagePullPolicy: IfNotPresent
         name: jqplay
         ports:
         - containerPort: 80

--- a/jqplay-service.yaml
+++ b/jqplay-service.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/jqplay-service.yaml
+++ b/jqplay-service.yaml
@@ -10,10 +10,12 @@ metadata:
     io.kompose.service: jqplay
   name: jqplay
 spec:
+  type: NodePort
   ports:
   - name: "3000"
     port: 3000
     targetPort: 80
+    nodePort: 30002
   selector:
     io.kompose.service: jqplay
 status:


### PR DESCRIPTION
I noticed there were some untested Kubernetes manifests (presumably checked in directly from `kompose` -- no judgement!). I decided I'd like it if they worked.

Tested on Kubernetes 1.21, which ships with Docker Desktop for Mac.

I also pinned the Dockerfile to an image where it would build successfully.